### PR TITLE
feat: implement weekly streak mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,20 @@ A demo workflow is available in [workflow-demo.yml](workflow-demo.yml) that show
 
 ## Inputs
 
-| Input           | Description                             | Required | Default             |
-| --------------- | --------------------------------------- | -------- | ------------------- |
-| `USERNAME`      | Your GitHub username                    | **Yes**  | N/A                 |
-| `GITHUB_TOKEN`  | Your GitHub token (PAT or GITHUB_TOKEN) | **Yes**  | N/A                 |
-| `THEME`         | Theme name (e.g., `default`, `dracula`) | No       | `default`           |
-| `OUTPUT_PATH`   | Path to save the SVG file               | No       | `github-streak.svg` |
-| `ANIMATED`      | Enable animations (`true` or `false`)   | No       | `true`              |
-| `LOCALE`        | Locale code (e.g., `en`, `ja`)          | No       | `en`                |
-| `DATE_FORMAT`   | Date format string                      | No       | `M j[, Y]`          |
-| `HIDE_BORDER`   | Hide the border (`true` or `false`)     | No       | `false`             |
-| `BORDER_RADIUS` | Corner radius                           | No       | `4.5`               |
-| `CARD_WIDTH`    | Card width                              | No       | `495`               |
-| `CARD_HEIGHT`   | Card height                             | No       | `195`               |
+| Input           | Description                                          | Required | Default             |
+| --------------- | ---------------------------------------------------- | -------- | ------------------- |
+| `USERNAME`      | Your GitHub username                                 | **Yes**  | N/A                 |
+| `GITHUB_TOKEN`  | Your GitHub token (PAT or GITHUB_TOKEN)              | **Yes**  | N/A                 |
+| `THEME`         | Theme name (e.g., `default`, `dracula`)              | No       | `default`           |
+| `OUTPUT_PATH`   | Path to save the SVG file                            | No       | `github-streak.svg` |
+| `ANIMATED`      | Enable animations (`true` or `false`)                | No       | `true`              |
+| `WEEK_STREAK`   | Count streak in weeks not days (`true` or `false`)   | No       | `false`             |
+| `LOCALE`        | Locale code (e.g., `en`, `ja`)                       | No       | `en`                |
+| `DATE_FORMAT`   | Date format string                                   | No       | `M j[, Y]`          |
+| `HIDE_BORDER`   | Hide the border (`true` or `false`)                  | No       | `false`             |
+| `BORDER_RADIUS` | Corner radius                                        | No       | `4.5`               |
+| `CARD_WIDTH`    | Card width                                           | No       | `495`               |
+| `CARD_HEIGHT`   | Card height                                          | No       | `195`               |
 
 ### Custom Color Overrides
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Enable animations"
     required: false
     default: "true"
+  WEEK_STREAK:
+    description: "Use week streak instead of day streak"
+    required: false
+    default: "false"
   LOCALE:
     description: "Locale for translations (e.g., en, ja, ko, zh_Hans)"
     required: false
@@ -99,6 +103,7 @@ runs:
         INPUT_THEME: ${{ inputs.THEME }}
         INPUT_OUTPUT_PATH: ${{ github.workspace }}/${{ inputs.OUTPUT_PATH }}
         INPUT_ANIMATED: ${{ inputs.ANIMATED }}
+        INPUT_WEEK_STREAK: ${{ inputs.WEEK_STREAK }}
         INPUT_LOCALE: ${{ inputs.LOCALE }}
         INPUT_DATE_FORMAT: ${{ inputs.DATE_FORMAT }}
         INPUT_BORDER_RADIUS: ${{ inputs.BORDER_RADIUS }}

--- a/src/action.ts
+++ b/src/action.ts
@@ -49,7 +49,7 @@ async function run() {
 
     // Fetch Data
     console.log("📡 Fetching GitHub data...");
-    const data = await fetchGitHubData(username, token);
+    const data = await fetchGitHubData(username, token, weekStreak);
     console.log(`   Total Contributions: ${data.totalContributions}`);
     const unit = weekStreak ? "weeks" : "days";
     console.log(`   Current Streak: ${data.currentStreak} ${unit}`);

--- a/src/action.ts
+++ b/src/action.ts
@@ -24,6 +24,7 @@ async function run() {
     const strokeType = (process.env.INPUT_STROKE_TYPE || "round") as
       | "round"
       | "butt";
+    const weekStreak = process.env.INPUT_WEEK_STREAK === "true";
 
     // Color overrides
     const fire = process.env.INPUT_FIRE;
@@ -42,6 +43,7 @@ async function run() {
 
     console.log(`🚀 Generating Streak Card for ${username}...`);
     console.log(`   Theme: ${theme}`);
+    console.log(`   Mode: ${weekStreak ? "Weekly" : "Daily"}`);
     console.log(`   Locale: ${locale}`);
     console.log(`   Output: ${outputPath}`);
 
@@ -49,8 +51,9 @@ async function run() {
     console.log("📡 Fetching GitHub data...");
     const data = await fetchGitHubData(username, token);
     console.log(`   Total Contributions: ${data.totalContributions}`);
-    console.log(`   Current Streak: ${data.currentStreak} days`);
-    console.log(`   Longest Streak: ${data.longestStreak} days`);
+    const unit = weekStreak ? "weeks" : "days";
+    console.log(`   Current Streak: ${data.currentStreak} ${unit}`);
+    console.log(`   Longest Streak: ${data.longestStreak} ${unit}`);
 
     // Generate Card
     console.log("🎨 Generating SVG...");
@@ -65,6 +68,7 @@ async function run() {
       dateFormat,
       numberFormat,
       strokeType,
+      weekStreak,
       // Color overrides (only if provided)
       ...(fire && { fire }),
       ...(ring && { ring }),

--- a/src/cardGenerator.ts
+++ b/src/cardGenerator.ts
@@ -38,8 +38,6 @@ export interface StreakCardData {
   longestStreakEndDate?: string;
   /** First contribution date */
   firstContributionDate: string;
-  /** Week streak (for week streak mode) */
-  weekStreak?: number;
   /** Longest week streak */
   longestWeekStreak?: number;
 }
@@ -338,8 +336,10 @@ function generateStreakContent(
   );
 
   // "Current Streak" label below ring
+  const streakLabel = weekStreak ? translations["Week Streak"] : translations["Current Streak"];
+
   lines.push(
-    renderText(translations["Current Streak"], centerX, centerLabelY, {
+    renderText(streakLabel, centerX, centerLabelY, {
       fill: colors.currStreakLabel,
       fontSize: 14,
       fontWeight: 400,
@@ -382,8 +382,10 @@ function generateStreakContent(
   );
 
   // Label below number
+  const longestLabel = weekStreak ? translations["Longest Week Streak"] : translations["Longest Streak"];
+
   lines.push(
-    renderText(translations["Longest Streak"], rightX, sideLabelY, {
+    renderText(longestLabel, rightX, sideLabelY, {
       fill: colors.sideLabels,
       fontSize: 14,
       fontWeight: 400,

--- a/src/cardGenerator.ts
+++ b/src/cardGenerator.ts
@@ -127,6 +127,7 @@ export function generateProfileCard(
     theme = "default",
     hideBorder = false,
     animate = true,
+    weekStreak = false,
     width = 495,
     height = 195,
     borderRadius = 4.5,
@@ -171,6 +172,7 @@ export function generateProfileCard(
     locale,
     numberFormat,
     animate,
+    weekStreak,
     strokeType,
   });
 
@@ -183,6 +185,7 @@ interface ContentOptions {
   locale: string;
   numberFormat: "short" | "full";
   animate: boolean;
+  weekStreak: boolean;
   strokeType: "round" | "butt";
 }
 
@@ -196,7 +199,7 @@ function generateStreakContent(
 ): string {
   const { colors, dimensions } = ctx;
   const { width, height } = dimensions;
-  const { dateFormat, locale, numberFormat, animate, strokeType } = options;
+  const { dateFormat, locale, numberFormat, animate, strokeType, weekStreak } = options;
 
   // Get translations
   const translations = getTranslations(locale);

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -34,6 +34,7 @@ interface GraphQLResponse {
 export async function fetchGitHubData(
   username: string,
   token: string,
+  useWeeks: boolean
 ): Promise<StreakCardData> {
   const query = `
     query($login: String!) {
@@ -87,8 +88,8 @@ export async function fetchGitHubData(
   const calendar = user.contributionsCollection.contributionCalendar;
   const days = calendar.weeks.flatMap((w) => w.contributionDays);
 
-  // Sort days by date
-  days.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const fallbackDate = days[days.length - 1]?.date || new Date().toISOString();
+  const today = new Date().toISOString().split('T')[0]!;
 
   // Calculate streaks
   let currentStreak = 0;
@@ -102,8 +103,8 @@ export async function fetchGitHubData(
     return {
       username,
       totalContributions: 0,
-      currentStreak: 0,
-      longestStreak: 0,
+      currentStreak,
+      longestStreak,
       streakStartDate: new Date().toISOString(),
       streakEndDate: new Date().toISOString(),
       longestStreakStartDate: new Date().toISOString(),
@@ -112,53 +113,97 @@ export async function fetchGitHubData(
     };
   }
 
-  // Calculate current streak (from end backwards)
-  let streak = 0;
-  for (let i = days.length - 1; i >= 0; i--) {
-    const day = days[i];
-    if (!day) continue;
+  // Sort days by date
+  days.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
-    if (day.contributionCount > 0) {
-      streak++;
-      currentStreakEnd = currentStreakEnd || day.date;
-      currentStreakStart = day.date;
-    } else {
-      // If today is 0, check if streak continues from yesterday
-      if (i === days.length - 1) {
-        continue;
+  if (useWeeks) {
+    // Gets previous sunday as a way to track weeks for each day.
+    const getPreviousSunday = (dateString: string): string => {
+      const date = new Date(dateString);
+      const dayOfWeek = date.getUTCDay();
+      date.setUTCDate(date.getUTCDate() - dayOfWeek);
+      return date.toISOString().split('T')[0]!;
+    }
+
+    // Calculate contributions per week
+    const weeksMap = new Map<string, number>();
+    const thisWeekSunday = getPreviousSunday(today);
+
+    days.forEach(day => {
+      const sunday = getPreviousSunday(day.date);
+      weeksMap.set(sunday, (weeksMap.get(sunday) || 0) + day.contributionCount);
+    });
+
+    // Sort weeks map to ensure order and for iterating
+    const sortedWeeks = Array.from(weeksMap.keys()).sort();
+    let tempWS = 0, tempStart = "";
+
+    // Calculate longest streak from weekly contritbutions
+    sortedWeeks.forEach((week) => {
+      const count = weeksMap.get(week) || 0;
+      if (count > 0) {
+        if (tempWS === 0) tempStart = week;
+        tempWS++;
+        if (tempWS > longestStreak) {
+          longestStreak = tempWS;
+          longestStreakStart = tempStart;
+          longestStreakEnd = week;
+        }
+      } else if (week !== thisWeekSunday) {
+        tempWS = 0;
       }
-      break;
+    });
+
+    currentStreak = tempWS;
+    currentStreakStart = tempStart || fallbackDate;
+    currentStreakEnd = sortedWeeks[sortedWeeks.length - 1] || fallbackDate;
+  } else {
+    // Calculate current streak (from end backwards)
+    let streak = 0;
+    for (let i = days.length - 1; i >= 0; i--) {
+      const day = days[i];
+      if (!day) continue;
+
+      if (day.contributionCount > 0) {
+        streak++;
+        currentStreakEnd = currentStreakEnd || day.date;
+        currentStreakStart = day.date;
+      } else {
+        // If today is 0, check if streak continues from yesterday
+        if (i === days.length - 1) {
+          continue;
+        }
+        break;
+      }
+    }
+    currentStreak = streak;
+
+    // Calculate longest streak with dates
+    let tempStreak = 0;
+    let tempStreakStart = "";
+    for (const day of days) {
+      if (day.contributionCount > 0) {
+        if (tempStreak === 0) {
+          tempStreakStart = day.date;
+        }
+        tempStreak++;
+      } else {
+        if (tempStreak > longestStreak) {
+          longestStreak = tempStreak;
+          longestStreakStart = tempStreakStart;
+          longestStreakEnd = days[days.indexOf(day) - 1]?.date || tempStreakStart;
+        }
+        tempStreak = 0;
+        tempStreakStart = "";
+      }
+    }
+    // Check if current streak is the longest
+    if (tempStreak > longestStreak) {
+      longestStreak = tempStreak;
+      longestStreakStart = tempStreakStart;
+      longestStreakEnd = days[days.length - 1]?.date || tempStreakStart;
     }
   }
-  currentStreak = streak;
-
-  // Calculate longest streak with dates
-  let tempStreak = 0;
-  let tempStreakStart = "";
-  for (const day of days) {
-    if (day.contributionCount > 0) {
-      if (tempStreak === 0) {
-        tempStreakStart = day.date;
-      }
-      tempStreak++;
-    } else {
-      if (tempStreak > longestStreak) {
-        longestStreak = tempStreak;
-        longestStreakStart = tempStreakStart;
-        longestStreakEnd = days[days.indexOf(day) - 1]?.date || tempStreakStart;
-      }
-      tempStreak = 0;
-      tempStreakStart = "";
-    }
-  }
-  // Check if current streak is the longest
-  if (tempStreak > longestStreak) {
-    longestStreak = tempStreak;
-    longestStreakStart = tempStreakStart;
-    longestStreakEnd = days[days.length - 1]?.date || tempStreakStart;
-  }
-
-  const fallbackDate = days[days.length - 1]?.date || new Date().toISOString();
 
   return {
     username,

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -8,10 +8,17 @@ interface GraphQLError {
   path?: string[];
 }
 
-interface GraphQLResponse {
-  data?: {
+interface GraphQLYearData {
+  user?: {
+    createdAt: string;
+    contributionsCollection: {
+      contributionYears: number[];
+    };
+  };
+}
+
+interface GraphQLCalendarData {
     user?: {
-      createdAt: string;
       contributionsCollection: {
         contributionCalendar: {
           totalContributions: number;
@@ -24,8 +31,41 @@ interface GraphQLResponse {
         };
       };
     };
-  };
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
   errors?: GraphQLError[];
+}
+
+/**
+ * Fetch GitHub streak data for a user
+ */
+async function fetchGraphQL<T>(token: string, query: string, variables: any): Promise<T> {
+  const response = await fetch(GITHUB_GRAPHQL_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API failed: ${response.status} ${response.statusText}`);
+  }
+
+  const json = (await response.json()) as GraphQLResponse<T>;
+  
+  if (json.errors) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+
+  if (!json.data) {
+    throw new Error("No data returned from GitHub API");
+  }
+
+  return json.data;
 }
 
 /**
@@ -36,11 +76,32 @@ export async function fetchGitHubData(
   token: string,
   useWeeks: boolean
 ): Promise<StreakCardData> {
-  const query = `
+  const yearQuery = `
     query($login: String!) {
       user(login: $login) {
         createdAt
         contributionsCollection {
+          contributionYears
+        }
+      }
+    }
+  `;
+
+  const yearData = await fetchGraphQL<GraphQLYearData>(token, yearQuery, { login: username });
+  
+  const user = yearData?.user;
+  if (!user) {
+    throw new Error(`User ${username} not found`);
+  }
+
+  const contributionYears: number[] = user.contributionsCollection.contributionYears;
+  const createdAt: string = user.createdAt;
+
+
+  const calendarQuery = `
+    query($login: String!, $from: DateTime!, $to: DateTime!) {
+      user(login: $login) {
+        contributionsCollection(from: $from, to: $to) {
           contributionCalendar {
             totalContributions
             weeks {
@@ -55,41 +116,52 @@ export async function fetchGitHubData(
     }
   `;
 
-  const response = await fetch(GITHUB_GRAPHQL_API, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      query,
-      variables: { login: username },
-    }),
-  });
+  // Create an array yearly calendar results
+  const yearlyResults = await Promise.all(contributionYears.map((year) => {
+    const from = `${year}-01-01T00:00:00Z`;
+    const to = `${year}-12-31T23:59:59Z`;
+    return fetchGraphQL<GraphQLCalendarData>(token, calendarQuery, { login: username, from, to });
+  }));
 
-  if (!response.ok) {
-    throw new Error(
-      `GitHub API failed: ${response.status} ${response.statusText}`,
-    );
+  // Create boundries
+  const todayDate = new Date();
+  const currentYear = todayDate.getUTCFullYear();
+  const today = todayDate.toISOString().split('T')[0]!;
+  
+  const tomorrowDate = new Date(todayDate);
+  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+  const tomorrow = tomorrowDate.toISOString().split('T')[0]!
+
+  // Aggregate all day contributions from all year results
+  let days: { contributionCount: number; date: string }[] = [];
+  let totalContributions = 0;
+
+  for (const [i, year] of yearlyResults.entries()) {
+    if (!year.user) {
+      throw new Error(`User ${username} not found`);
+    }
+
+    const yearNum = contributionYears[i];
+    const calendar = year.user.contributionsCollection.contributionCalendar;
+    totalContributions += calendar.totalContributions;
+    
+    let daysInYear = calendar.weeks.flatMap((w: any) => w.contributionDays);
+
+    // Filter out future dates
+    if (yearNum === currentYear) {
+      daysInYear = daysInYear.filter((day) => {
+        return day.date <= today || (day.date === tomorrow && day.contributionCount > 0);
+      });
+    }
+
+    days.push(...daysInYear);
   }
 
-  const json = (await response.json()) as GraphQLResponse;
-
-  if (json.errors) {
-    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors)}`);
-  }
-
-  const user = json.data?.user;
-  if (!user) {
-    throw new Error(`User ${username} not found`);
-  }
+  // Sort days by date
+  days.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
   // Process Contributions & Streaks
-  const calendar = user.contributionsCollection.contributionCalendar;
-  const days = calendar.weeks.flatMap((w) => w.contributionDays);
-
-  const fallbackDate = days[days.length - 1]?.date || new Date().toISOString();
-  const today = new Date().toISOString().split('T')[0]!;
+  const fallbackDate = days[days.length - 1]?.date || today;
 
   // Calculate streaks
   let currentStreak = 0;
@@ -109,12 +181,9 @@ export async function fetchGitHubData(
       streakEndDate: new Date().toISOString(),
       longestStreakStartDate: new Date().toISOString(),
       longestStreakEndDate: new Date().toISOString(),
-      firstContributionDate: user.createdAt,
+      firstContributionDate: createdAt,
     };
   }
-
-  // Sort days by date
-  days.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
   if (useWeeks) {
     // Gets previous sunday as a way to track weeks for each day.
@@ -181,7 +250,7 @@ export async function fetchGitHubData(
     // Calculate longest streak with dates
     let tempStreak = 0;
     let tempStreakStart = "";
-    for (const day of days) {
+    for (const [index, day] of days.entries()) {
       if (day.contributionCount > 0) {
         if (tempStreak === 0) {
           tempStreakStart = day.date;
@@ -191,7 +260,7 @@ export async function fetchGitHubData(
         if (tempStreak > longestStreak) {
           longestStreak = tempStreak;
           longestStreakStart = tempStreakStart;
-          longestStreakEnd = days[days.indexOf(day) - 1]?.date || tempStreakStart;
+          longestStreakEnd = days[index - 1]?.date || tempStreakStart;
         }
         tempStreak = 0;
         tempStreakStart = "";
@@ -207,13 +276,13 @@ export async function fetchGitHubData(
 
   return {
     username,
-    totalContributions: calendar.totalContributions,
+    totalContributions,
     currentStreak,
     longestStreak,
     streakStartDate: currentStreakStart || fallbackDate,
     streakEndDate: currentStreakEnd || fallbackDate,
     longestStreakStartDate: longestStreakStart || fallbackDate,
     longestStreakEndDate: longestStreakEnd || fallbackDate,
-    firstContributionDate: user.createdAt,
+    firstContributionDate: createdAt,
   };
 }

--- a/tests/cardGenerator.test.ts
+++ b/tests/cardGenerator.test.ts
@@ -123,3 +123,42 @@ describe("Card Generator", () => {
     expect(svg).toBeTruthy();
   });
 });
+
+describe("Weekly Streak Mode", () => {
+  test("uses weekly labels and correct values from currentStreak", () => {
+    const data: StreakCardData = {
+      ...MOCK_DATA,
+      currentStreak: 5, // This is the '5 weeks' calculated by your API
+      longestStreak: 12,
+    };
+
+    const options: CardOptions = {
+      weekStreak: true, // This triggers the label change
+      locale: "en",
+    };
+
+    const svg = generateProfileCard(data, options);
+
+    // Verify values (Shared variables)
+    expect(svg).toContain(">5</text>");
+    expect(svg).toContain(">12</text>");
+
+    // Verify labels (Controlled by the option flag)
+    expect(svg).toContain("Week Streak");
+    expect(svg).toContain("Longest Week Streak");
+    expect(svg).not.toContain("Current Streak");
+  });
+
+  test("respects different locales for weekly labels", () => {
+    const options: CardOptions = {
+      weekStreak: true,
+      locale: "ja",
+    };
+
+    const svg = generateProfileCard(MOCK_DATA, options);
+
+    // Verify Japanese weekly labels from translations.ts
+    expect(svg).toContain("週間ストリーク");
+    expect(svg).toContain("最長の週間ストリーク");
+  });
+});


### PR DESCRIPTION
## Description
This PR introduces a **Weekly Streak** mode to the generator. It allows users to track their contributions based on standard calendar weeks (Sunday–Saturday) instead of individual days. 

While the codebase had internal placeholders for weekly stats, the logic to calculate, translate, and render those stats was missing, and the option was not exposed to the GitHub Action. This PR completes that pipeline.

## Changes

### 1. Input Infrastructure (Commit 1)
* **`action.yml`**: Added `WEEK_STREAK` input (defaults to `false`).
* **`README.md`**: Added `WEEK_STREAK` to inputs table.
* **`src/action.ts`**: 
* Updated the Action entry point to capture the `WEEK_STREAK` environment variable and propagate it to both the data fetcher and card generator.
*  Added logging - clear console logs to the Action output to confirm if it is running in "Daily" or "Weekly" mode.
* **`cardGenerator.ts`**: Updated types and function params for new input.

### 2. Weekly Logic & Rendering (Commit 2)
* **`src/github-api.ts`**: 
    * Added a boolean param `useWeeks` to optimized  streak counts so that it only calculates weekly stats if true, skipping daily logic entirely to save resources.
    * Implemented an "Active" week count: the streak does not reset until a full calendar week is missed, giving the user until the end of the current week to maintain their streak.
    * Logic for weekly count is from [DenverCoder1/github-readme-streak-stats](https://github.com/DenverCoder1/github-readme-streak-stats/blob/main/src/stats.php). 
* **`cardGenerator.ts`**:
    * Integrated the labels with the existing `translations.ts` for multi-language support.
    * Dropped the optional `weekStreak` param, not needed anymore since `fetchGitHubData` only returns what the mode requires.
* **`action.yml`**: Added new useWeeks param to fetchGitHubData function call.
* **`tests/cardGenerator.test.ts`**:
    * Added new test suites to verify weekly label rendering and translation support.
    
### 3. Full Historical Data Fetching (Commit 3)
* **`src/github-api.ts`**:
    * Overhauled the GraphQL fetching logic to bypass the GitHub API's default 365-day limit on the `contributionCalendar`.
    * Implemented a two-step query architecture: first retrieving an array of all active `contributionYears` for the user, then executing parallel GraphQL requests for every year.
    * Aggregated and chronologically sorted all historical days into a single master array prior to streak calculation, ensuring lifetime Total Contributions and Longest Streaks are fully accurate.

## Testing
- [x] Verified that setting `WEEK_STREAK: "true"` generates a card with "Week Streak" labels and accurate weekly counts.
- [x] Confirmed that "Daily" mode remains the default and is unaffected.